### PR TITLE
kernel module: Fix missing bpf_prog_run

### DIFF
--- a/kernel/iptables-trace.c
+++ b/kernel/iptables-trace.c
@@ -73,6 +73,10 @@ static int __bpf_check_path(struct bpf_prog **prog, char *path)
     return PTR_ERR_OR_ZERO(*prog);
 }
 
+#ifdef BPF_PROG_RUN
+#define bpf_prog_run(prog, ctx) BPF_PROG_RUN(prog, ctx)
+#endif
+
 static bool __run_bpf_prog_entry(struct pt_regs *regs)
 {
     return !!bpf_prog_run(__ipt_bpf_prog_entry, regs);


### PR DESCRIPTION
Fix issue #1.

`bpf_prog_run` is missing in old kernel, which was macro `BPF_PROG_RUN`.

To fix it, define a macro `bpf_prog_run` alias to `BPF_PROG_RUN`.